### PR TITLE
Dependency restore mode and refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
+checksum = "ca87830a3e3fb156dc96cfbd31cb620265dd053be734723f22b760d6cc3c3051"
 
 [[package]]
 name = "async-broadcast"
@@ -294,9 +294,9 @@ checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
 
 [[package]]
 name = "async-trait"
-version = "0.1.75"
+version = "0.1.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf6721fb0140e4f897002dd086c06f6c27775df19cfe1fccb21181a48fd2c98"
+checksum = "531b97fb4cd3dfdce92c35dedbfdc1f0b9d8091c8ca943d6dae340ef5012d514"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
@@ -1769,12 +1769,12 @@ dependencies = [
 
 [[package]]
 name = "os_pipe"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae859aa07428ca9a929b936690f8b12dc5f11dd8c6992a18ca93919f28bc177"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1983,8 +1983,8 @@ dependencies = [
 
 [[package]]
 name = "qpm_package"
-version = "0.3.0"
-source = "git+https://github.com/QuestPackageManager/QPM.Package.git#a329c9253eb67dacc1aeecda871c17b1fa7b5347"
+version = "1.0.0"
+source = "git+https://github.com/QuestPackageManager/QPM.Package.git#92a0646a975b1b89a988b28fc783323a8e4c2f19"
 dependencies = [
  "cursed-semver-parser",
  "semver",
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "similar"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "slab"
@@ -2681,18 +2681,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
+checksum = "b2cd5904763bad08ad5513ddbb12cf2ae273ca53fa9f68e843e236ec6dfccc09"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
+checksum = "3dcf4a824cce0aeacd6f38ae6f24234c8e80d68632338ebaa1443b5df9e29e19"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "a293318316cf6478ec1ad2a21c49390a8d5b5eae9fab736467d93fbc0edc29c5"
 dependencies = [
  "unicode-ident",
 ]
@@ -1984,7 +1984,7 @@ dependencies = [
 [[package]]
 name = "qpm_package"
 version = "1.0.0"
-source = "git+https://github.com/QuestPackageManager/QPM.Package.git#92a0646a975b1b89a988b28fc783323a8e4c2f19"
+source = "git+https://github.com/QuestPackageManager/QPM.Package.git#6010e21053491ad5a0e40fe192bb42cbfafe9ac5"
 dependencies = [
  "cursed-semver-parser",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ trycmd = "0.14"
 
 [dependencies]
 #qpm
-qpm_package = { git = "https://github.com/QuestPackageManager/QPM.Package.git", tag = "v0.3.0"}
+qpm_package = { git = "https://github.com/QuestPackageManager/QPM.Package.git"}
 qpm_qmod = { git = "https://github.com/QuestPackageManager/QPM.Qmod.git" }
 qpm_arg_tokenizer = { git = "https://github.com/QuestPackageManager/QPM.arg_tokenizer.git" }
 templatr = { git = "https://github.com/QuestPackageManager/templatr.git", optional = true }

--- a/src/commands/package/create.rs
+++ b/src/commands/package/create.rs
@@ -4,7 +4,7 @@ use clap::Args;
 use owo_colors::OwoColorize;
 use qpm_package::models::{
     extra::AdditionalPackageMetadata,
-    package::{PackageConfig, PackageMetadata, self},
+    package::{self, PackageConfig, PackageMetadata},
 };
 use semver::Version;
 
@@ -26,18 +26,9 @@ pub struct PackageOperationCreateArgs {
     /// Specify that this package is headers only and does not contain a .so or .a file
     #[clap(long = "headersOnly")]
     pub headers_only: Option<bool>,
-    /// Specify that this package is static linking
-    #[clap(long = "staticLinking")]
-    pub static_linking: Option<bool>,
     /// Specify the download link for a release .so or .a file
     #[clap(long = "soLink")]
     pub so_link: Option<String>,
-    /// Specify the download link for a debug .so or .a files (usually from the obj folder)
-    #[clap(long = "debugSoLink")]
-    pub debug_so_link: Option<String>,
-    /// Override the downloaded .so or .a filename with this name instead.
-    #[clap(long = "overrideSoName")]
-    pub override_so_name: Option<String>,
 }
 
 impl Command for PackageOperationCreateArgs {
@@ -54,10 +45,7 @@ impl Command for PackageOperationCreateArgs {
         let additional_data = AdditionalPackageMetadata {
             branch_name: self.branch_name,
             headers_only: self.headers_only,
-            static_linking: self.static_linking,
             so_link: self.so_link,
-            debug_so_link: self.debug_so_link,
-            override_so_name: self.override_so_name,
             ..Default::default()
         };
 

--- a/src/commands/package/edit_extra.rs
+++ b/src/commands/package/edit_extra.rs
@@ -93,24 +93,12 @@ impl Command for EditExtraArgs {
             package_edit_extra_headers_only(&mut package, headers_only.into());
             any_changed = true;
         }
-        if let Some(static_linking) = self.static_linking {
-            package_edit_extra_static_linking(&mut package, static_linking.into());
-            any_changed = true;
-        }
         if let Some(so_link) = self.so_link {
             package_edit_extra_so_link(&mut package, so_link);
             any_changed = true;
         }
-        if let Some(debug_so_link) = self.debug_so_link {
-            package_edit_extra_debug_so_link(&mut package, debug_so_link);
-            any_changed = true;
-        }
         if let Some(mod_link) = self.mod_link {
             package_edit_extra_mod_link(&mut package, mod_link);
-            any_changed = true;
-        }
-        if let Some(override_so_name) = self.override_so_name {
-            package_edit_extra_override_so_name(&mut package, override_so_name);
             any_changed = true;
         }
         if let Some(sub_folder) = self.sub_folder {
@@ -145,11 +133,6 @@ pub fn package_edit_extra_headers_only(package: &mut PackageConfig, headers_only
     package.info.additional_data.headers_only = Some(headers_only);
 }
 
-pub fn package_edit_extra_static_linking(package: &mut PackageConfig, static_linking: bool) {
-    println!("Setting static_linking: {static_linking:#?}");
-    package.info.additional_data.static_linking = Some(static_linking);
-}
-
 pub fn package_edit_extra_so_link(package: &mut PackageConfig, so_link: String) {
     println!("Setting so_link: {so_link:#?}");
     package.info.additional_data.so_link = Some(so_link);
@@ -158,16 +141,6 @@ pub fn package_edit_extra_so_link(package: &mut PackageConfig, so_link: String) 
 pub fn package_edit_extra_mod_link(package: &mut PackageConfig, mod_link: String) {
     println!("Setting mod_link: {mod_link:#?}");
     package.info.additional_data.mod_link = Some(mod_link);
-}
-
-pub fn package_edit_extra_debug_so_link(package: &mut PackageConfig, debug_so_link: String) {
-    println!("Setting debug_so_link: {debug_so_link:#?}");
-    package.info.additional_data.debug_so_link = Some(debug_so_link);
-}
-
-pub fn package_edit_extra_override_so_name(package: &mut PackageConfig, override_so_name: String) {
-    println!("Setting override_so_name: {override_so_name:#?}");
-    package.info.additional_data.override_so_name = Some(override_so_name);
 }
 
 pub fn package_edit_extra_sub_folder(package: &mut PackageConfig, sub_folder: String) {

--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -13,23 +13,21 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use qpm_package::{
-    extensions::package_metadata::PackageMetadataExtensions,
-    models::{
-        backend::PackageVersion, dependency::SharedPackageConfig, extra::DependencyLibType,
-        package::PackageConfig,
-    },
+use qpm_package::models::{
+    backend::PackageVersion,
+    dependency::{SharedDependency, SharedPackageConfig},
+    extra::DependencyLibType,
+    package::PackageConfig,
 };
 
 use crate::{
-    models::{
-        config::get_combine_config, package::PackageConfigExtensions,
-        package_dependeny::PackageDependencyExtensions,
-    },
+    models::{config::get_combine_config, package::PackageConfigExtensions},
+    terminal::colors::QPMColor,
     utils::{fs::copy_things, json},
 };
 
 use super::Repository;
+use crate::models::package_dependeny::DependencyExtensions;
 
 // TODO: Somehow make a global singleton of sorts/cached instance to share across places
 // like resolver
@@ -87,10 +85,9 @@ impl FileRepository {
     pub fn add_artifact_and_cache(
         &mut self,
         package: SharedPackageConfig,
-        project_folder: PathBuf,
-        binary_path: Option<PathBuf>,
-        debug_binary_path: Option<PathBuf>,
-        static_binary_path: Option<PathBuf>,
+        project_folder: &Path,
+        binary_path: Option<&Path>,
+        static_binary_path: Option<&Path>,
         copy: bool,
         overwrite_existing: bool,
     ) -> Result<()> {
@@ -99,7 +96,6 @@ impl FileRepository {
                 &package,
                 project_folder,
                 binary_path,
-                debug_binary_path,
                 static_binary_path,
                 false,
             )?;
@@ -110,25 +106,24 @@ impl FileRepository {
     }
 
     fn copy_to_cache(
-        package: &SharedPackageConfig,
-        project_folder: PathBuf,
-        binary_path: Option<PathBuf>,
-        debug_binary_path: Option<PathBuf>,
-        static_binary_path: Option<PathBuf>,
+        shared_package: &SharedPackageConfig,
+        project_folder: &Path,
+        binary_path: Option<&Path>,
+        static_binary_path: Option<&Path>,
         validate: bool,
     ) -> Result<()> {
         println!(
             "Adding cache for local dependency {} {}",
-            package.config.info.id.bright_red(),
-            package.config.info.version.bright_green()
+            shared_package.config.info.id.bright_red(),
+            shared_package.config.info.version.bright_green()
         );
         let config = get_combine_config();
         let cache_path = config
             .cache
             .as_ref()
             .unwrap()
-            .join(&package.config.info.id)
-            .join(package.config.info.version.to_string());
+            .join(&shared_package.config.info.id)
+            .join(shared_package.config.info.version.to_string());
 
         let tmp_path = cache_path.join("tmp");
         let src_path = cache_path.join("src");
@@ -139,38 +134,26 @@ impl FileRepository {
 
         fs::create_dir_all(&src_path).context("Failed to create lib path")?;
 
-        if binary_path.is_some() || debug_binary_path.is_some() || static_binary_path.is_some() {
-            let lib_path = cache_path.join("lib");
-            let so_path = lib_path.join(package.config.info.get_so_name());
-            let static_path = lib_path.join(package.config.info.get_static_name());
-            let debug_so_path = lib_path.join(format!(
-                "debug_{}",
-                package
-                    .config
-                    .info
-                    .get_so_name()
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy()
-            ));
+        let lib_path = cache_path.join("lib");
 
-            if let Some(binary_path_unwrapped) = &binary_path {
-                copy_things(binary_path_unwrapped, &so_path)?;
-            }
+        if let Some(binary_path_unwrapped) = &binary_path {
+            let dynamic_out_name = shared_package.get_dynamic_lib_out()?.file_name().unwrap();
+            let so_path = lib_path.join(dynamic_out_name);
 
-            if let Some(debug_binary_path_unwrapped) = &debug_binary_path {
-                copy_things(debug_binary_path_unwrapped, &debug_so_path)?;
-            }
-            if let Some(static_binary_path_unwrapped) = &static_binary_path {
-                copy_things(static_binary_path_unwrapped, &static_path)?;
-            }
+            copy_things(binary_path_unwrapped, &so_path)?;
         }
 
-        let original_shared_path = project_folder.join(&package.config.shared_dir);
+        if let Some(static_binary_path_unwrapped) = &static_binary_path {
+            let static_out_name = shared_package.get_static_lib_out()?.file_name().unwrap();
+            let static_out_path = lib_path.join(static_out_name);
+            copy_things(static_binary_path_unwrapped, &static_out_path)?;
+        }
+
+        let original_shared_path = project_folder.join(&shared_package.config.shared_dir);
 
         copy_things(
             &original_shared_path,
-            &src_path.join(&package.config.shared_dir),
+            &src_path.join(&shared_package.config.shared_dir),
         )?;
         copy_things(&project_folder.join("qpm.json"), &src_path.join("qpm.json"))?;
         copy_things(
@@ -188,17 +171,22 @@ impl FileRepository {
             let downloaded_package = SharedPackageConfig::read(package_path)?;
 
             // check if downloaded config is the same version as expected, if not, panic
-            if downloaded_package.config.info.version != package.config.info.version {
+            if downloaded_package.config.info.version != shared_package.config.info.version {
                 bail!(
                     "Downloaded package ({}) version ({}) does not match expected version ({})!",
-                    package.config.info.id.bright_red(),
+                    shared_package.config.info.id.bright_red(),
                     downloaded_package
                         .config
                         .info
                         .version
                         .to_string()
                         .bright_green(),
-                    package.config.info.version.to_string().bright_green(),
+                    shared_package
+                        .config
+                        .info
+                        .version
+                        .to_string()
+                        .bright_green(),
                 )
             }
         }
@@ -246,11 +234,11 @@ impl FileRepository {
     }
 
     pub fn copy_from_cache(
-        package: &PackageConfig,
+        shared_package: &SharedPackageConfig,
         restored_deps: &[SharedPackageConfig],
         workspace_dir: &Path,
     ) -> Result<()> {
-        let files = Self::collect_deps(package, restored_deps, workspace_dir)?;
+        let files = Self::collect_deps(shared_package, restored_deps, workspace_dir)?;
 
         let config = get_combine_config();
         let symlink = config.symlink.unwrap_or(true);
@@ -307,14 +295,19 @@ impl FileRepository {
     }
 
     pub fn collect_deps(
-        package: &PackageConfig,
+        shared_package: &SharedPackageConfig,
         restored_deps: &[SharedPackageConfig],
         workspace_dir: &Path,
     ) -> Result<HashMap<PathBuf, PathBuf>> {
-        // let package = shared_package.config;
+        let package = &shared_package.config;
         let restored_dependencies_map: HashMap<&String, &SharedPackageConfig> = restored_deps
             .iter()
             .map(|p| (&p.config.info.id, p))
+            .collect();
+        let locked_dependencies_map: HashMap<&String, &SharedDependency> = shared_package
+            .restored_dependencies
+            .iter()
+            .map(|p| (&p.dependency.id, p))
             .collect();
 
         let user_config = get_combine_config();
@@ -338,160 +331,136 @@ impl FileRepository {
 
         let extern_dir = workspace_dir.join(&package.dependencies_dir);
 
-        // delete if needed
-        if extern_dir.exists() {
-            fs::remove_dir_all(&extern_dir)
-                .with_context(|| format!("Unable to delete {extern_dir:?}"))?;
-        }
-
         let extern_binaries = extern_dir.join("libs");
         let extern_headers = extern_dir.join("includes");
-        let mut paths = HashMap::<PathBuf, PathBuf>::new();
 
-        // direct deps (binaries)
-        for referenced_dep in &package.dependencies {
-            let shared_dep = restored_dependencies_map.get(&referenced_dep.id).unwrap();
-            let dep_cache_path = base_path
-                .join(&referenced_dep.id)
-                .join(shared_dep.config.info.version.to_string());
-            let libs_path = dep_cache_path.join("lib");
+        let headers = locked_dependencies_map.iter().map(
+            |(dep_id, shared_dep)| -> Result<(PathBuf, PathBuf)> {
+                let shared_dep_config =
+                    restored_dependencies_map.get(dep_id).unwrap_or_else(|| {
+                        panic!(
+                            "No shared config in resolved_deps for dependency {}:{}",
+                            dep_id.dependency_id_color(),
+                            shared_dep.version.dependency_version_color()
+                        )
+                    });
 
-            let lib_type_opt = referenced_dep.infer_lib_type(&shared_dep.config);
+                let dep_cache_path = base_path
+                    .join(dep_id)
+                    .join(shared_dep_config.config.info.version.to_string());
 
-            // skip header only deps
-            if shared_dep
-                .config
-                .info
-                .additional_data
-                .headers_only
-                .unwrap_or(false)
-                // if dependency is requested as header only
-                || lib_type_opt == DependencyLibType::HeaderOnly
-            {
-                if referenced_dep
-                    .additional_data
-                    .lib_type
-                    .as_ref()
-                    .is_some_and(|t| *t != DependencyLibType::HeaderOnly)
-                {
-                    eprintln!(
-                        "Header only library {} is requested as {:?}",
-                        shared_dep.config.info.id, lib_type_opt
+                let src_path = dep_cache_path.join("src");
+
+                if !src_path.exists() {
+                    bail!(
+                        "Missing src for dependency {}:{}",
+                        dep_id,
+                        shared_dep_config.config.info.version.to_string()
                     );
                 }
-                continue;
-            }
 
-            // Not header only
-            let data = &shared_dep.config.info.additional_data;
+                let exposed_headers = src_path.join(&shared_dep_config.config.shared_dir);
+                let project_deps_headers_target = extern_headers.join(dep_id);
 
-            let name = match lib_type_opt {
-                // if has so link and is not using static_link
-                // use so name
-                DependencyLibType::Shared
-                    if (data.debug_so_link.is_some() || data.so_link.is_some()) =>
-                {
-                    match data.debug_so_link.is_none() {
-                        true => shared_dep.config.info.get_so_name(),
-                        false => format!(
-                            "debug_{}",
-                            shared_dep
-                                .config
-                                .info
-                                .get_so_name()
-                                .file_name()
-                                .unwrap()
-                                .to_string_lossy()
-                        )
-                        .into(),
+                let path = (
+                    exposed_headers,
+                    project_deps_headers_target.join(&shared_dep_config.config.shared_dir),
+                );
+
+                Ok(path)
+            },
+        );
+
+        let binaries = locked_dependencies_map
+            .iter()
+            .filter(|(_dep_id, shared_dep)| shared_dep.restored_lib_type != DependencyLibType::HeaderOnly)
+            .map(|(dep_id, shared_dep)| -> Result<(PathBuf, PathBuf)> {
+                let data = &shared_dep.dependency.additional_data;
+
+                let dep_cache_path = base_path
+                    .join(dep_id)
+                    .join(shared_dep.version.to_string());
+                let libs_path = dep_cache_path.join("lib");
+
+                let src_path = dep_cache_path.join("src");
+
+                if !src_path.exists() {
+                    bail!(
+                        "Missing src for dependency {}:{}",
+                        dep_id,
+                        shared_dep.version.to_string()
+                    );
+                }
+
+                let dependency_lib_type = shared_dep.restored_lib_type.clone();
+                let name = match dependency_lib_type {
+                    // if has so link and is not using static_link
+                    // use so name
+                    DependencyLibType::Shared if data.so_link.is_some() => {
+                        shared_dep.dependency.get_dynamic_lib_out()?
                     }
+                    DependencyLibType::Static if data.static_link.is_some() => {
+                        shared_dep.dependency.get_static_lib_out()?
+                    }
+                    _ => bail!("Attempting to use dependency as {dependency_lib_type:?} but failed. Info: {data:?}"),
+                };
+
+                let src_binary = libs_path.join(name);
+
+                if !src_binary.exists() {
+                    bail!(
+                        "Missing binary {} for {}:{}",
+                        name.file_name().unwrap().to_string_lossy(),
+                        dep_id,
+                        shared_dep.version
+                    );
                 }
-                // if dependency is static and has static_linking
-                DependencyLibType::Static
-                    if data.static_linking.unwrap_or(false) && data.so_link.is_some() =>
-                {
-                    shared_dep.config.info.get_so_name().with_extension("a")
-                }
-                DependencyLibType::Static if data.static_link.is_some() => {
-                    shared_dep.config.info.get_static_name()
-                }
-                _ => bail!(
-                    "Attempting to use dependency as {lib_type_opt:?} but failed. Info: {data:?}"
-                ),
-            };
+                let dst_binary =
+                    extern_binaries.join(name.file_name().unwrap().to_str().unwrap());
 
-            let src_binary = libs_path.join(&name);
-
-            if !src_binary.exists() {
-                bail!(
-                    "Missing binary {} for {}:{}",
-                    name.file_name().unwrap().to_string_lossy(),
-                    referenced_dep.id,
-                    shared_dep.config.info.version
-                );
-            }
-
-            paths.insert(
-                src_binary,
-                extern_binaries.join(name.file_name().unwrap().to_str()),
-            );
-        }
-
-        // Get headers of all dependencies restored
-        for (restored_id, restored_dep) in &restored_dependencies_map {
-            let dep_cache_path = base_path
-                .join(restored_id)
-                .join(restored_dep.config.info.version.to_string());
-            let src_path = dep_cache_path.join("src");
-
-            if !src_path.exists() {
-                bail!(
-                    "Missing src for dependency {}:{}",
-                    restored_id,
-                    restored_dep.config.info.version.to_string()
-                );
-            }
-
-            let exposed_headers = src_path.join(&restored_dep.config.shared_dir);
-            let project_deps_headers_target = extern_headers.join(restored_id);
-
-            paths.insert(
-                exposed_headers,
-                project_deps_headers_target.join(&restored_dep.config.shared_dir),
-            );
-        }
+                let path = (src_binary, dst_binary);
+                Ok(path)
+            });
 
         // extra files
-        // while this is looped twice, generally I'd assume the compiler to properly
-        // optimize this and it's better readability
-        for referenced_dependency in &package.dependencies {
-            let shared_dep = restored_dependencies_map
-                .get(&referenced_dependency.id)
-                .unwrap();
+        let extra_files = package
+            .dependencies
+            .iter()
+            .map(|referenced_dependency| {
+                let shared_dep = restored_dependencies_map
+                    .get(&referenced_dependency.id)
+                    .unwrap();
 
-            let dep_cache_path = base_path
-                .join(&referenced_dependency.id)
-                .join(shared_dep.config.info.version.to_string());
-            let src_path = dep_cache_path.join("src");
+                let dep_cache_path = base_path
+                    .join(&referenced_dependency.id)
+                    .join(shared_dep.config.info.version.to_string());
+                let src_path = dep_cache_path.join("src");
 
-            let extern_headers_dep = extern_headers.join(&referenced_dependency.id);
+                let mut paths: Vec<(PathBuf, PathBuf)> = vec![];
 
-            if let Some(extras) = &referenced_dependency.additional_data.extra_files {
-                for extra in extras {
-                    let extra_src = src_path.join(extra);
+                let extern_headers_dep = extern_headers.join(&referenced_dependency.id);
+                if let Some(extras) = &referenced_dependency.additional_data.extra_files {
+                    for extra in extras {
+                        let extra_src = src_path.join(extra);
 
-                    if !extra_src.exists() {
-                        bail!(
-                            "Missing extra {extra} for dependency {}:{}",
-                            referenced_dependency.id,
-                            shared_dep.config.info.version.to_string()
-                        );
+                        if !extra_src.exists() {
+                            bail!(
+                                "Missing extra {extra} for dependency {}:{}",
+                                referenced_dependency.id,
+                                shared_dep.config.info.version.to_string()
+                            );
+                        }
+
+                        paths.push((extra_src, extern_headers_dep.join(extra)));
                     }
-
-                    paths.insert(extra_src, extern_headers_dep.join(extra));
                 }
-            }
-        }
+
+                Ok(paths)
+            })
+            .flatten_ok();
+
+        let mut paths: HashMap<PathBuf, PathBuf> =
+            headers.chain(binaries).chain(extra_files).try_collect()?;
 
         paths.retain(|src, _| src.exists());
 

--- a/src/tests/mocks/repo.rs
+++ b/src/tests/mocks/repo.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use qpm_package::models::extra::DependencyLibType;
 use qpm_package::models::{
     dependency::{Dependency, SharedDependency, SharedPackageConfig},
     extra::AdditionalPackageMetadata,
@@ -65,6 +66,7 @@ pub fn build_artifact_and_depend(
         restored_dependencies: vec![SharedDependency {
             dependency: dep,
             version: shared_dep.config.info.version.clone(),
+            restored_lib_type: DependencyLibType::HeaderOnly,
         }],
     }
 }
@@ -106,6 +108,7 @@ pub fn build_artifact_and_depends(
                     additional_data: shared_config.config.info.additional_data.clone(),
                 },
                 version: shared_config.config.info.version.clone(),
+                restored_lib_type: DependencyLibType::HeaderOnly,
             })
             .collect(),
     }

--- a/src/utils/cmake.rs
+++ b/src/utils/cmake.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use color_eyre::{eyre::Context, Result};
-use qpm_package::{models::dependency::SharedPackageConfig, extensions::package_metadata::PackageMetadataExtensions};
+use qpm_package::models::dependency::SharedPackageConfig;
 
 use crate::repository::Repository;
 use std::fmt::Write as OtherWrite;
@@ -262,11 +262,7 @@ pub fn make_defines_string(dep: &SharedPackageConfig) -> Result<String> {
     )?;
     result.push_str("# derived from override .so name or just id_version\n");
 
-    writeln!(
-        result,
-        "set(COMPILE_ID \"{}\")",
-        dep.config.info.get_module_id()
-    )?;
+    writeln!(result, "set(COMPILE_ID \"{}\")", dep.config.info.id)?;
 
     result.push_str(
         "# derived from whichever codegen package is installed, will default to just codegen\n",

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,9 +1,9 @@
-use std::{fs, path::PathBuf};
+use std::{fs, path::Path};
 
 use color_eyre::Result;
 use fs_extra::{dir::copy as copy_directory, file::copy as copy_file};
 
-pub fn copy_things(a: &PathBuf, b: &PathBuf) -> Result<()> {
+pub fn copy_things(a: &Path, b: &Path) -> Result<()> {
     if a.is_dir() {
         fs::create_dir_all(b)?;
     } else {


### PR DESCRIPTION
- Use QPM.Package 1.0.0
- Properly support `dynamicLibOut` and `staticLibOut`
- Store `libDependencyType` in `qpm.shared.json`
- Refactor qpm qmod build for more flexibility
- Refactor `qpm install` to use `dynamicLibOut` and/or `staticLibOut`
- Allow choosing to restore header only, static or dynamic
- No longer excluding `modloader` by default
- Remove debug dynamic libraries
- Remove `overrideSoName`
- CMake `COMPILE_ID` now uses `qpm.json` id