### PR TITLE
NDK Workspace setup (2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,8 +2818,7 @@ dependencies = [
 [[package]]
 name = "zip"
 version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+source = "git+https://github.com/nichmor/zip2.git?branch=fix/soft-links-should-remain-the-same#a3232a211904e396274a0ff632438f24667e21f6"
 dependencies = [
  "aes",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,11 @@ pubgrub = "0.2"
 owo-colors = "4"
 dirs = "5.0.0"
 keyring = "3"
-zip = "2"
+
+# Use PR with symlink fix for Unix systems.
+# zip = "2"
+zip = { git = "https://github.com/nichmor/zip2.git", branch = "fix/soft-links-should-remain-the-same", version = "2.1.3" }
+
 walkdir = "2"
 symlink = "0.1.0"
 fs_extra = "1.2"

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -179,7 +179,7 @@ impl Command for Ndk {
                             .is_ok_and(|version| ndk_requirement.matches(&version))
                     })
                     .ok_or_else(|| {
-                        eyre!("No NDK version found that satisfies {ndk_requirement}")
+                        eyre!("No NDK version installed that satisfies {ndk_requirement}")
                     })?;
 
                 apply_ndk(ndk_installed_path.path())?;

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -121,7 +121,8 @@ impl Command for Ndk {
                 let manifest = get_android_manifest()?;
 
                 let (_version, ndk) = fuzzy_match_ndk(&manifest, &d.version)?;
-                download_ndk_version(ndk)?
+                download_ndk_version(ndk)?;
+                return Ok(());
             }
             NdkOperation::Available(a) => {
                 let manifest = get_android_manifest()?;
@@ -250,19 +251,9 @@ fn do_resolve(r: ResolveArgs) -> Result<(), color_eyre::eyre::Error> {
         // download
         None if r.download => {
             let manifest = get_android_manifest()?;
-            let (version, _package) = range_match_ndk(&manifest, ndk_requirement)?;
+            let (_version, ndk) = range_match_ndk(&manifest, ndk_requirement)?;
 
-            let ndk_path = format!(
-                "{}/{version}",
-                get_combine_config()
-                    .ndk_download_path
-                    .as_ref()
-                    .unwrap()
-                    .to_str()
-                    .unwrap()
-            );
-
-            ndk_path.into()
+            download_ndk_version(ndk)?
         }
         // error
         _ => {

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -41,7 +41,9 @@ pub enum NdkOperation {
     List,
     Available(AvailableArgs),
     Path(PathArgs),
+    ///  Apply the current NDK requirements (installed only, highest version that is valid). Download if necessary
     Resolve(ResolveArgs),
+    /// Set the current NDK requirements (highest installed NDK version, allow non-installed versions if desired)
     Use(UseArgs),
 }
 
@@ -60,6 +62,7 @@ pub struct PathArgs {
 }
 #[derive(Args, Debug, Clone)]
 pub struct UseArgs {
+    /// NDK Version that should be required
     version: String,
 
     /// Use strict = for version constraint
@@ -69,8 +72,10 @@ pub struct UseArgs {
     #[clap(long, default_value = "true")]
     installed_only: bool,
 }
+
 #[derive(Args, Debug, Clone)]
 pub struct ResolveArgs {
+    /// Download package if necessary
     #[clap(short, long, default_value = "false")]
     download: bool,
 }

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -123,7 +123,8 @@ impl Command for Ndk {
                 let manifest = get_android_manifest()?;
 
                 let (_version, ndk) = fuzzy_match_ndk(&manifest, &d.version)?;
-                download_ndk_version(ndk)?;
+                let path = download_ndk_version(ndk)?;
+                println!("{}", path.display());
                 return Ok(());
             }
             NdkOperation::Available(a) => {

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -1,4 +1,7 @@
-use std::{fs::File, path::Path};
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
 
 use clap::{Args, Subcommand};
 use color_eyre::{
@@ -63,11 +66,14 @@ pub struct UseArgs {
     #[clap(long, default_value = "false")]
     strict: bool,
 
-    #[clap(long, default_value = "false")]
+    #[clap(long, default_value = "true")]
     installed_only: bool,
 }
 #[derive(Args, Debug, Clone)]
-pub struct ResolveArgs {}
+pub struct ResolveArgs {
+    #[clap(short, long, default_value = "false")]
+    download: bool,
+}
 
 fn fuzzy_match_ndk<'a>(
     manifest: &'a AndroidRepositoryManifest,
@@ -167,97 +173,122 @@ impl Command for Ndk {
 
                 println!("{}", ndk_path.display());
             }
-            NdkOperation::Resolve(r) => {
-                let package = PackageConfig::read(".")?;
-                let ndk_requirement = package.workspace.ndk.as_ref();
-
-                let Some(ndk_requirement) = ndk_requirement else {
-                    bail!("No NDK requirement set in project")
-                };
-                // find latest NDK that satisfies requirement
-                let ndk_installed_path = get_combine_config()
-                    .get_ndk_installed()
-                    .into_iter()
-                    .flatten()
-                    .sorted_by(|a, b| a.file_name().cmp(b.file_name()))
-                    .rev() // descending
-                    .find(|s| {
-                        Version::parse(s.file_name().to_str().unwrap())
-                            .is_ok_and(|version| ndk_requirement.matches(&version))
-                    })
-                    .ok_or_else(|| {
-                        let report =
-                            eyre!("No NDK version installed that satisfies {ndk_requirement}");
-
-                        // look up a version suitable to work with
-                        // allow this to work offline by handling safely
-                        let manifest = get_android_manifest().ok();
-                        let suggested_version = manifest
-                            .as_ref()
-                            .and_then(|manifest| range_match_ndk(manifest, ndk_requirement).ok());
-
-                        match suggested_version {
-                            Some((suggested_version, _)) => {
-                                report.suggestion(format!("qpm ndk download {suggested_version}"))
-                            }
-                            None => report,
-                        }
-                    })?;
-
-                apply_ndk(ndk_installed_path.path())?;
-            }
-            NdkOperation::Use(u) => {
-                let version = match u.installed_only {
-                    true => {
-                        let version_req = VersionReq::parse(&u.version)?;
-                        // find latest NDK that satisfies requirement
-                        let ndk_installed_path = get_combine_config()
-                            .get_ndk_installed()
-                            .into_iter()
-                            .flatten()
-                            .sorted_by(|a, b| a.file_name().cmp(b.file_name()))
-                            .rev()
-                            .find(|n| {
-                                Version::parse(n.file_name().to_str().unwrap())
-                                    .is_ok_and(|v| version_req.matches(&v))
-                            })
-                            .ok_or_else(|| {
-                                eyre!("No NDK version instaleled that satisfies {version_req}")
-                            })?;
-
-                        ndk_installed_path.file_name().to_str().unwrap().to_string()
-                    }
-                    // allow any NDK version online
-                    false => {
-                        let manifest = get_android_manifest()?;
-                        fuzzy_match_ndk(&manifest, &u.version)?.0
-                    }
-                };
-
-                let mut package = PackageConfig::read(".")?;
-                let req = match u.strict {
-                    true => format!("={version}"),
-                    false => format!("^{version}"),
-                };
-                package.workspace.ndk = Some(VersionReq::parse(&req)?);
-                package.write(".")?;
-
-                let ndk_path = format!(
-                    "{}/{version}",
-                    get_combine_config()
-                        .ndk_download_path
-                        .as_ref()
-                        .unwrap()
-                        .to_str()
-                        .unwrap()
-                );
-
-                apply_ndk(Path::new(&ndk_path))?;
-            }
+            NdkOperation::Resolve(r) => do_resolve(r)?,
+            NdkOperation::Use(u) => do_use(u)?,
         }
 
         Ok(())
     }
+}
+
+fn do_use(u: UseArgs) -> Result<(), color_eyre::eyre::Error> {
+    let version = match u.installed_only {
+        true => {
+            let version_req = VersionReq::parse(&u.version)?;
+            // find latest NDK that satisfies requirement
+            let ndk_installed_path = get_combine_config()
+                .get_ndk_installed()
+                .into_iter()
+                .flatten()
+                .sorted_by(|a, b| a.file_name().cmp(b.file_name()))
+                .rev()
+                .find(|n| {
+                    Version::parse(n.file_name().to_str().unwrap())
+                        .is_ok_and(|v| version_req.matches(&v))
+                })
+                .ok_or_else(|| {
+                    eyre!("No NDK version installed that satisfies {version_req}")
+                })?;
+
+            ndk_installed_path.file_name().to_str().unwrap().to_string()
+        }
+        // allow any NDK version online
+        false => {
+            let manifest = get_android_manifest()?;
+            fuzzy_match_ndk(&manifest, &u.version)?.0
+        }
+    };
+    let mut package = PackageConfig::read(".")?;
+    let req = match u.strict {
+        true => format!("={version}"),
+        false => format!("^{version}"),
+    };
+    package.workspace.ndk = Some(VersionReq::parse(&req)?);
+    package.write(".")?;
+    let ndk_path = format!(
+        "{}/{version}",
+        get_combine_config()
+            .ndk_download_path
+            .as_ref()
+            .unwrap()
+            .to_str()
+            .unwrap()
+    );
+    apply_ndk(Path::new(&ndk_path))?;
+    Ok(())
+}
+
+fn do_resolve(r: ResolveArgs) -> Result<(), color_eyre::eyre::Error> {
+    let package = PackageConfig::read(".")?;
+    let ndk_requirement = package.workspace.ndk.as_ref();
+    let Some(ndk_requirement) = ndk_requirement else {
+        bail!("No NDK requirement set in project")
+    };
+    let ndk_installed_path_opt = get_combine_config()
+        .get_ndk_installed()
+        .into_iter()
+        .flatten()
+        .sorted_by(|a, b| a.file_name().cmp(b.file_name()))
+        .rev() // descending
+        .find(|s| {
+            Version::parse(s.file_name().to_str().unwrap())
+                .is_ok_and(|version| ndk_requirement.matches(&version))
+        });
+    let ndk_installed_path: PathBuf = match ndk_installed_path_opt {
+        // NDK Found, unwrap
+        Some(ndk_installed_path) => ndk_installed_path.path().into(),
+        // download
+        None if r.download => {
+            let manifest = get_android_manifest()?;
+            let (version, _package) = range_match_ndk(&manifest, ndk_requirement)?;
+
+            let ndk_path = format!(
+                "{}/{version}",
+                get_combine_config()
+                    .ndk_download_path
+                    .as_ref()
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+            );
+
+            ndk_path.into()
+        }
+        // error
+        _ => {
+            let mut report =
+                eyre!("No NDK version installed that satisfies {ndk_requirement}")
+                    .note("-d/--download not set, not downloading!");
+
+            // look up a version suitable to work with
+            // allow this to work offline by handling safely
+            let manifest = get_android_manifest().ok();
+            let mut suggested_version = manifest
+                .as_ref()
+                .and_then(|manifest| range_match_ndk(manifest, ndk_requirement).ok());
+
+            if let Some((suggested_version, _)) = &mut suggested_version {
+                report =
+                    report.suggestion(format!("qpm ndk download {suggested_version}"));
+            }
+
+            return Err(report);
+        }
+    };
+
+    // apply the NDK to the environment
+    apply_ndk(&ndk_installed_path)?;
+    Ok(())
 }
 
 // apply NDK to project and write

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -240,6 +240,7 @@ impl Command for Ndk {
                     false => format!("^{version}"),
                 };
                 package.workspace.ndk = Some(VersionReq::parse(&req)?);
+                package.write(".")?;
 
                 let ndk_path = format!(
                     "{}/{version}",

--- a/src/commands/ndk.rs
+++ b/src/commands/ndk.rs
@@ -15,16 +15,13 @@ use semver::{Version, VersionReq};
 use std::io::Write;
 
 use crate::{
-    models::{
+    commands::ndk, models::{
         android_repo::{AndroidRepositoryManifest, RemotePackage},
         config::get_combine_config,
         package::PackageConfigExtensions,
-    },
-    resolver::semver::{req_to_range, VersionWrapper},
-    terminal::colors::QPMColor,
-    utils::android::{
+    }, resolver::semver::{req_to_range, VersionWrapper}, terminal::colors::QPMColor, utils::android::{
         download_ndk_version, get_android_manifest, get_ndk_str_versions, get_ndk_str_versions_str,
-    },
+    }
 };
 
 use super::Command;
@@ -290,7 +287,8 @@ fn do_resolve(r: ResolveArgs) -> Result<(), color_eyre::eyre::Error> {
 // apply NDK to project and write
 fn apply_ndk(ndk_installed_path: &Path) -> Result<(), color_eyre::eyre::Error> {
     let mut ndk_file = File::create("./ndkpath.txt").context("Unable to open ndkpath.txt")?;
-    writeln!(ndk_file, "{}", ndk_installed_path.to_str().unwrap())?;
+    write!(ndk_file, "{}", ndk_installed_path.to_str().unwrap())?;
+    ndk_file.flush()?;
     println!("{}", ndk_installed_path.to_str().unwrap());
     Ok(())
 }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,4 +1,4 @@
-use std::{env, fs::File, io::Read, path::Path};
+use std::{env, fs::File, io::Read, path::{Path, PathBuf}};
 
 use clap::Args;
 
@@ -116,7 +116,13 @@ pub fn validate_ndk(package: &PackageConfig) -> Result<()> {
         return Ok(());
     };
 
-    let mut ndk_file = File::open("./ndkpath.txt")?;
+    // early return, the file doesn't exist nothing to validate
+    let ndk_file_path = Path::new("./ndkpath.txt");
+    if !ndk_file_path.exists() {
+        return Ok(());
+    }
+
+    let mut ndk_file = File::open(ndk_file_path)?;
 
     let mut ndk_path_str = String::new();
     ndk_file.read_to_string(&mut ndk_path_str)?;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -121,7 +121,7 @@ pub fn validate_ndk(package: &PackageConfig) -> Result<()> {
     let mut ndk_path_str = String::new();
     ndk_file.read_to_string(&mut ndk_path_str)?;
 
-    let ndk_path = Path::new(&ndk_path_str);
+    let ndk_path = Path::new(ndk_path_str.trim());
     if !ndk_path.exists() {
         bail!("NDK Path {} does not exist!", ndk_path.display());
     }

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -105,6 +105,8 @@ impl Command for RestoreCommand {
         dependency::restore(".", &shared_package, &resolved_deps, &mut repo)?;
         shared_package.write(".")?;
 
+        validate_ndk(&shared_package.config)?;
+
         Ok(())
     }
 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -7,6 +7,7 @@ use std::{
 
 use color_eyre::{eyre::Context, Result};
 use serde::{Deserialize, Serialize};
+use walkdir::WalkDir;
 
 use crate::utils::json;
 
@@ -106,6 +107,14 @@ impl UserConfig {
             },
             None => global,
         })
+    }
+
+    pub fn get_ndk_installed(&self) -> WalkDir {
+        let dir = get_combine_config()
+            .ndk_download_path
+            .as_ref()
+            .expect("No NDK download path set");
+        WalkDir::new(dir).max_depth(1)
     }
 }
 

--- a/src/network/agent.rs
+++ b/src/network/agent.rs
@@ -105,6 +105,7 @@ where
     });
 
     progress_bar.finish_println("Finished download!");
+    println!();
 
     result
 }

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -34,12 +34,18 @@ pub fn get_ndk_packages(manifest: &AndroidRepositoryManifest) -> Vec<&RemotePack
 }
 
 pub fn get_ndk_version(ndk: &RemotePackage) -> Version {
+    let build = BuildMetadata::new(&format!(
+        "preview-{}",
+        &ndk.revision.preview.unwrap_or(0).to_string()
+    ))
+    .unwrap();
+
     Version {
         major: ndk.revision.major.unwrap_or(0),
         minor: ndk.revision.minor.unwrap_or(0),
         patch: ndk.revision.micro.unwrap_or(0),
-        pre: Prerelease::new(&ndk.revision.preview.unwrap_or(0).to_string()).unwrap(),
-        build: BuildMetadata::default(),
+        pre: Prerelease::EMPTY,
+        build,
     }
 }
 

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -131,7 +131,7 @@ pub fn download_ndk_version(ndk: &RemotePackage) -> Result<PathBuf> {
     );
 
     // Rename to use friendly NDK version name
-    let final_path = extract_path.with_file_name(get_ndk_version(ndk).to_string());
+    let final_path = dir.join(get_ndk_version(ndk).to_string());
 
     fs::rename(&extract_path, &final_path)?;
 

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, io::Cursor, path::PathBuf};
+use std::{collections::HashMap, env, fs, io::Cursor, path::PathBuf};
 
 use bytes::{BufMut, BytesMut};
 use color_eyre::Result;
@@ -129,5 +129,9 @@ pub fn download_ndk_version(ndk: &RemotePackage) -> Result<PathBuf> {
         get_ndk_version(ndk).green(),
         final_path.to_str().unwrap().file_path_color()
     );
-    Ok(dir)
+
+    // Rename to use friendly NDK version name
+    fs::rename(&final_path, final_path.with_file_name(get_ndk_version(ndk).to_string()))?;
+
+    Ok(final_path)
 }

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -120,18 +120,20 @@ pub fn download_ndk_version(ndk: &RemotePackage) -> Result<PathBuf> {
 
     // Extract to tmp folde
     let mut archive = ZipArchive::new(buffer)?;
-    let final_path = dir.join(archive.by_index(0)?.name());
+    let extract_path = dir.join(archive.by_index(0)?.name());
 
     archive.extract(&dir)?;
 
     println!(
         "Downloaded {} to {}",
         get_ndk_version(ndk).green(),
-        final_path.to_str().unwrap().file_path_color()
+        extract_path.to_str().unwrap().file_path_color()
     );
 
     // Rename to use friendly NDK version name
-    fs::rename(&final_path, final_path.with_file_name(get_ndk_version(ndk).to_string()))?;
+    let final_path = extract_path.with_file_name(get_ndk_version(ndk).to_string());
+
+    fs::rename(&extract_path, &final_path)?;
 
     Ok(final_path)
 }

--- a/src/utils/android.rs
+++ b/src/utils/android.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, io::Cursor};
+use std::{collections::HashMap, env, io::Cursor, path::PathBuf};
 
 use bytes::{BufMut, BytesMut};
 use color_eyre::Result;
@@ -95,7 +95,7 @@ pub fn get_host_archive(ndk: &RemotePackage) -> Option<&Archive> {
     })
 }
 
-pub fn download_ndk_version(ndk: &RemotePackage) -> Result<()> {
+pub fn download_ndk_version(ndk: &RemotePackage) -> Result<PathBuf> {
     let archive = get_host_archive(ndk).expect("Could not find ndk for current os and arch");
 
     let archive_url = format!("{ANDROID_DL_URL}/{}", archive.complete.url);
@@ -108,7 +108,7 @@ pub fn download_ndk_version(ndk: &RemotePackage) -> Result<()> {
 
     let dir = get_combine_config()
         .ndk_download_path
-        .as_ref()
+        .clone()
         .expect("No NDK download path set");
     let _name = &archive.complete.url;
 
@@ -122,12 +122,12 @@ pub fn download_ndk_version(ndk: &RemotePackage) -> Result<()> {
     let mut archive = ZipArchive::new(buffer)?;
     let final_path = dir.join(archive.by_index(0)?.name());
 
-    archive.extract(dir)?;
+    archive.extract(&dir)?;
 
     println!(
         "Downloaded {} to {}",
         get_ndk_version(ndk).green(),
         final_path.to_str().unwrap().file_path_color()
     );
-    Ok(())
+    Ok(dir)
 }


### PR DESCRIPTION
Adds two new commands intended to facilitate setup for NDK across projects.

- `qpm ndk resolve` - Attempts to look for a suitable NDK version in the NDK path that satisfies the requirement in `qpm.json::workspace::ndkRequirement`. If none found, error. If any found, uses the newest version that satisfies the requirement and writes the path to `ndkpath.txt`. Finally writes it to `stdout` for friendly parsing. Add `-d/--download` for automatic downloading.
- `qpm ndk pin` - Adds the NDK version requirement to the `qpm.json` file. Writes to `stdout` and `ndkpath.txt`

