### PR TITLE
Update workflows again

### DIFF
--- a/.github/workflows/cargo-bleeding-release.yml
+++ b/.github/workflows/cargo-bleeding-release.yml
@@ -34,11 +34,14 @@ jobs:
           pattern: qpm-*
           path: artifacts
 
-      - name: Move bleeding tag
+      - name: Delete bleeding tag
         run: |
-          git tag -f bleeding
-          git push -f origin bleeding
+          git push -d origin bleeding || true
 
+      # Give GitHub time to delete the old release
+      - name: Sleep
+        run: sleep 10
+        
       - name: Bleeeding Artifact Upload
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/cargo-bleeding-release.yml
+++ b/.github/workflows/cargo-bleeding-release.yml
@@ -1,0 +1,52 @@
+# Runs on push to main.
+name: Cargo Bleeding Release
+
+on:
+  push:
+    branches: 
+      - 'main'
+
+concurrency:
+  group: bleeding-release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/cargo-build.yml
+    with:
+      version: ${{ needs.extract_tag.outputs.version }}
+
+  bleeding-release:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: qpm-*
+          path: artifacts
+
+      - name: Move bleeding tag
+        run: |
+          git tag -f bleeding
+          git push -f origin bleeding
+
+      - name: Bleeeding Artifact Upload
+        uses: softprops/action-gh-release@v1
+        with:
+          body: |
+            This is an automatic release generated from the last successful commit to the main branch.  While this was a successful build, the resulting binary may not be fully stable.
+
+            SHA: ${{ github.sha }}
+          name: 'Latest Build on main'
+          tag_name: bleeding
+          prerelease: true
+          files: artifacts/**/*

--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -17,16 +17,6 @@ on:
         required: false
         type: string
         default: 1.0.0
-  
-  push:
-    branches: [main]
-    paths-ignore:
-      - "README.md"
-      - "**.json"
-      - "**.yml"
-      - "LICENSE"
-      - "!.github/workflows/cargo-build.yml"
-      - "installer/**"
 
 jobs:
   version:

--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -51,20 +51,24 @@ jobs:
         include:
           - os: ubuntu-latest
             file-name: qpm
-            prefix: linux-x64
+            prefix: linux
+            suffix: linux-x64
 
           - os: macos-13
             file-name: qpm
             prefix: macos-x64
+            suffix: macos-x64
 
           - os: macos-13
             file-name: qpm
             prefix: macos-arm64
+            suffix: macos-arm64
             target: aarch64-apple-darwin
 
           - os: windows-latest
             file-name: qpm.exe
-            prefix: windows-x64
+            prefix: windows
+            suffix: windows-x64
 
     steps:
       - uses: actions/checkout@v4
@@ -128,14 +132,22 @@ jobs:
       - name: Compress build
         if: ${{ matrix.file-name != '' && matrix.prefix != '' }}
         run: |
-          pwsh -Command Compress-Archive ./target/${{ matrix.target }}/release/${{matrix.file-name}} -DestinationPath qpm-${{matrix.prefix}}.zip
+          pwsh -Command Compress-Archive ./target/${{ matrix.target }}/release/${{matrix.file-name}} -DestinationPath qpm-${{matrix.suffix}}.zip
+
+      - name: Artifact Upload (Archive)
+        if: ${{ matrix.prefix != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: qpm-${{matrix.suffix}}
+          path: qpm-${{matrix.suffix}}.zip
+          if-no-files-found: error
 
       - name: Artifact Upload
         if: ${{ matrix.prefix != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: qpm-${{matrix.prefix}}
-          path: qpm-${{matrix.prefix}}.zip
+          name: ${{matrix.prefix}}-qpm
+          path: target/${{ matrix.target }}/release/${{matrix.file-name}}
           if-no-files-found: error
 
       - name: Download Inno Setup
@@ -187,9 +199,16 @@ jobs:
           lipo -create -output qpm qpm-macos-x64/qpm qpm-macos-arm64/qpm
           pwsh -Command Compress-Archive qpm -DestinationPath qpm-macos-universal.zip
 
-      - name: Artifact Upload
+      - name: Artifact Upload (Archive)
         uses: actions/upload-artifact@v4
         with:
           name: qpm-macos-universal
           path: qpm-macos-universal.zip
+          if-no-files-found: error
+
+      - name: Artifact Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-universal-qpm
+          path: qpm
           if-no-files-found: error

--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ matrix.prefix != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: qpm-${{matrix.suffix}}
+          name: qpm-${{matrix.suffix}}.zip
           path: qpm-${{matrix.suffix}}.zip
           if-no-files-found: error
 
@@ -170,19 +170,14 @@ jobs:
       - name: Download Intel macOS build
         uses: actions/download-artifact@v4
         with:
-          name: qpm-macos-x64
+          name: macos-x64-qpm
           path: qpm-macos-x64
 
       - name: Download ARM macOS build
         uses: actions/download-artifact@v4
         with:
-          name: qpm-macos-arm64
+          name: macos-arm64-qpm
           path: qpm-macos-arm64
-
-      - name: Unzip the artifacts
-        run: |
-          pwsh -Command Expand-Archive -Path "qpm-macos-x64/qpm-macos-x64.zip" -DestinationPath "qpm-macos-x64"
-          pwsh -Command Expand-Archive -Path "qpm-macos-arm64/qpm-macos-arm64.zip" -DestinationPath "qpm-macos-arm64"
 
       - name: Make Universal Binary
         run: |
@@ -192,13 +187,13 @@ jobs:
       - name: Artifact Upload (Archive)
         uses: actions/upload-artifact@v4
         with:
-          name: qpm-macos
+          name: qpm-macos-universal.zip
           path: qpm-macos-universal.zip
           if-no-files-found: error
 
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:
-          name: macos-qpm
+          name: macos-universal-qpm
           path: qpm
           if-no-files-found: error

--- a/.github/workflows/cargo-build.yml
+++ b/.github/workflows/cargo-build.yml
@@ -192,13 +192,13 @@ jobs:
       - name: Artifact Upload (Archive)
         uses: actions/upload-artifact@v4
         with:
-          name: qpm-macos-universal
+          name: qpm-macos
           path: qpm-macos-universal.zip
           if-no-files-found: error
 
       - name: Artifact Upload
         uses: actions/upload-artifact@v4
         with:
-          name: macos-universal-qpm
+          name: macos-qpm
           path: qpm
           if-no-files-found: error

--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: qpm-*
           path: artifacts
 
       - name: Release Artifact Upload


### PR DESCRIPTION
#56 changed the artifact name and format which broke the bleeding edge version for qpm-action, this PR uploads two sets of run artifacts.  The qpm-* artifacts which are release-ready archived versions, and the *-qpm artifacts which are the uncompressed files that the action downloads.

This PR also adds a bleeding release workflow that runs on any push to main and creates a pre-release with the resulting artifacts.  This can be more convenient than having to download a run artifact, and provides a consistent url for the bleeding builds.