### PR TITLE
Restore release binary instead of debug

### DIFF
--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -370,15 +370,15 @@ impl FileRepository {
         }
 
         // get so name or release so name
-        let name = match package.info.additional_data.debug_so_link.is_none() {
-            true => package
+        let name = match package.info.additional_data.so_link {
+            None => package
                 .info
                 .get_so_name2()
                 .file_name()
                 .unwrap()
                 .to_string_lossy()
                 .to_string(),
-            false => format!(
+            Some(_) => format!(
                 "debug_{}",
                 package
                     .info


### PR DESCRIPTION
Essentially, restore the release binary instead of the `debug` binary.

The reasons are as follows, though not entirely without its drawbacks.
Pros:
- Less storage used
- No confusion for a debug build being bundled
- Linking to a binary as expected to be used in production (though this is a nonissue as we strip the debug binary for the release)

Cons:
- Currently, the debug binary is still downloaded to cache, though this is easily resolved.
- No NDK-stack support for dependencies with linked defined functions.

However, I do think that the pros outweigh the cons especially given that the debug symbols for dependencies aren't entirely necessary. Tombstones often include function names and paper logger includes line numbers. Additionally, [crash analyzer](https://analyzer.questmodding.com/crashes/) uses `ndk-stack` with all of qpm's available debug binaries, thereby mitigating the issues mentioned. 

This is especially profound when published packages such as BSML occupy 100MB **per package cached**, and some templates incur a copy of these dependencies into the build folder, doubling storage occupied for a very minor improvement in granular debugging for dependencies. As #60 also mentions, this can cause accidental bundling of debug binaries when one intended the release binary instead.
