### PR TITLE
Add `--clean` flag to `qpm qmod zip`

### DIFF
--- a/src/commands/qmod/zip.rs
+++ b/src/commands/qmod/zip.rs
@@ -56,6 +56,11 @@ pub struct ZipQmodOperationArgs {
     #[clap(long, default_value = "false")]
     pub(crate) offline: bool,
 
+    /// Run the clean script before building
+    #[clap(long = "clean", default_value = "false")]
+    pub(crate) clean: bool,
+
+    /// Don't run the build script
     #[clap(long = "skip_build", default_value = "false")]
     pub(crate) skip_build: bool,
 
@@ -97,6 +102,16 @@ pub(crate) fn execute_qmod_zip_operation(build_parameters: ZipQmodOperationArgs)
             offline: build_parameters.offline,
         },
     )?;
+
+    if build_parameters.clean {
+        // Run clean script
+        let clean_script = &package.workspace.get_clean();
+        if let Some(clean_script) = clean_script
+        {
+            println!("Running clean script");
+            scripts::invoke_script(clean_script, &[], &package)?;
+        }
+    }
 
     // Run build script
     let build_script = &package.workspace.get_build();


### PR DESCRIPTION
Introduce a `--clean` flag that allows users to run the `clean` script before building, enhancing the flexibility of the `qpm qmod zip` command.